### PR TITLE
Adds support for lead api and page hits

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -42,13 +42,24 @@ class LeadApiController extends CommonApiController
         // Check for an email to see if the lead already exists
         $parameters = $this->request->request->all();
 
-        if (array_key_exists('email', $parameters)) {
-            $lead = $this->model->getRepository()->getLeadByEmail($parameters['email']);
+        $uniqueLeadFields    = $this->factory->getModel('lead.field')->getUniqueIdentiferFields();
+        $uniqueLeadFieldData = array();
 
-            if (!empty($lead)) {
-                // Lead found so edit rather than create a new one
+        foreach ($parameters as $k => $v) {
+            if (array_key_exists($k, $uniqueLeadFields) && !empty($v)) {
+                $uniqueLeadFieldData[$k] = $v;
+            }
+        }
 
-                return parent::editEntityAction($lead['id']);
+        if (count($uniqueLeadFieldData)) {
+            if (count($uniqueLeadFieldData)) {
+                $existingLeads = $this->factory->getEntityManager()->getRepository('MauticLeadBundle:Lead')->getLeadsByUniqueFields($uniqueLeadFieldData);
+
+                if (!empty($existingLeads)) {
+                    // Lead found so edit rather than create a new one
+
+                    return parent::editEntityAction($existingLeads[0]->getId());
+                }
             }
         }
 

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -419,7 +419,7 @@ class LeadController extends FormController
                         $data[$f->getName()] = $f->getData();
                     }
 
-                    $model->setFieldValues($lead, $data);
+                    $model->setFieldValues($lead, $data, true);
 
                     //form is valid so process the data
                     $model->saveEntity($lead);
@@ -569,7 +569,7 @@ class LeadController extends FormController
                         }
                     }
 
-                    $model->setFieldValues($lead, $data);
+                    $model->setFieldValues($lead, $data, true);
                     //form is valid so process the data
                     $model->saveEntity($lead, $form->get('buttons')->get('save')->isClicked());
 

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -154,14 +154,9 @@ class LeadRepository extends CommonRepository
             ->select('l')
             ->from('MauticLeadBundle:Lead', 'l');
 
-        // if we have a lead ID add it to our query
-        if (!empty($leadId)) {
-            $q->where(
-                $q->expr()->in('l.id', ':ids')
-            );
-        }
-
-        $q
+        $q->where(
+            $q->expr()->in('l.id', ':ids')
+        )
             ->setParameter('ids', $ids)
             ->orderBy('l.dateAdded', 'DESC');
 

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -201,13 +201,11 @@ class LeadModel extends FormModel
      * @param $overwriteWithBlank
      * @return array
      */
-    public function setFieldValues(Lead &$lead, array $data, $overwriteWithBlank = true)
+    public function setFieldValues(Lead &$lead, array $data, $overwriteWithBlank = false)
     {
         //@todo - add a catch to NOT do social gleaning if a lead is created via a form, etc as we do not want the user to experience the wait
         //generate the social cache
         list($socialCache, $socialFeatureSettings) = $this->factory->getHelper('integration')->getUserProfiles($lead, $data, true, null, false, true);
-
-        $isNew = ($lead->getId()) ? false : true;
 
         //set the social cache while we have it
         $lead->setSocialCache($socialCache);
@@ -235,29 +233,33 @@ class LeadModel extends FormModel
                     $field['value'] = null;
                 }
 
-                $curValue = $field['value'];
-                $newValue = (isset($data[$alias])) ? $data[$alias] : "";
-                if ($curValue !== $newValue && (!empty($newValue) || (empty($newValue) && $overwriteWithBlank))) {
-                    $field['value'] = $newValue;
-                    $lead->addUpdatedField($alias, $newValue, $curValue);
-                }
+                // Only update fields that are part of the passed $data array
+                if (array_key_exists($alias, $data)) {
+                    $curValue = $field['value'];
+                    $newValue = $data[$alias];
 
-                //if empty, check for social media data to plug the hole
-                if (empty($newValue) && !empty($socialCache)) {
-                    foreach ($socialCache as $service => $details) {
-                        //check to see if a field has been assigned
+                    if ($curValue !== $newValue && (!empty($newValue) || (empty($newValue) && $overwriteWithBlank))) {
+                        $field['value'] = $newValue;
+                        $lead->addUpdatedField($alias, $newValue, $curValue);
+                    }
 
-                        if (!empty($socialFeatureSettings[$service]['leadFields']) &&
-                            in_array($field['alias'], $socialFeatureSettings[$service]['leadFields'])
-                        ) {
+                    //if empty, check for social media data to plug the hole
+                    if (empty($newValue) && !empty($socialCache)) {
+                        foreach ($socialCache as $service => $details) {
+                            //check to see if a field has been assigned
 
-                            //check to see if the data is available
-                            $key = array_search($field['alias'], $socialFeatureSettings[$service]['leadFields']);
-                            if (isset($details['profile'][$key])) {
-                                //Found!!
-                                $field['value'] = $details['profile'][$key];
-                                $lead->addUpdatedField($alias, $details['profile'][$key]);
-                                break;
+                            if (!empty($socialFeatureSettings[$service]['leadFields'])
+                                && in_array($field['alias'], $socialFeatureSettings[$service]['leadFields'])
+                            ) {
+
+                                //check to see if the data is available
+                                $key = array_search($field['alias'], $socialFeatureSettings[$service]['leadFields']);
+                                if (isset($details['profile'][$key])) {
+                                    //Found!!
+                                    $field['value'] = $details['profile'][$key];
+                                    $lead->addUpdatedField($alias, $details['profile'][$key]);
+                                    break;
+                                }
                             }
                         }
                     }

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -425,38 +425,46 @@ class PageModel extends FormModel
                     // Update lead fields if some data were sent in the URL query
                     /** @var \Mautic\LeadBundle\Model\FieldModel $leadFieldModel */
                     $leadFieldModel      = $this->factory->getModel('lead.field');
-                    $availableLeadFields = $leadFieldModel->getFieldList(false, false, array(
-                        'isPublished'         => true,
-                        'isPubliclyUpdatable' => true
-                    ));
+                    $availableLeadFields = $leadFieldModel->getFieldList(
+                        false,
+                        false,
+                        array(
+                            'isPublished'         => true,
+                            'isPubliclyUpdatable' => true
+                        )
+                    );
 
-                    $inQuery = array_intersect_key($query, $availableLeadFields);
+                    $uniqueLeadFields    = $this->factory->getModel('lead.field')->getUniqueIdentiferFields();
+                    $uniqueLeadFieldData = array();
+                    $inQuery             = array_intersect_key($query, $availableLeadFields);
                     foreach ($inQuery as $k => $v) {
                         if (empty($query[$k])) {
                             unset($inQuery[$k]);
                         }
+
+                        if (array_key_exists($k, $uniqueLeadFields)) {
+                            $uniqueLeadFieldData[$k] = $v;
+                        }
                     }
 
                     if (count($inQuery)) {
-                        if (isset($inQuery['email'])) {
-                            // Make sure a lead does not currently exist if the current lead doesn't match
-                            $fields = $lead->getFields();
-                            if (strtolower($inQuery['email']) != $fields['core']['email']['value']) {
-                                $exists = $leadModel->getRepository()->getLeadsByFieldValue('email', $inQuery['email'], $lead->getId());
-                                if (!empty($exists)) {
-                                    //merge with current lead
-                                    $lead = $leadModel->mergeLeads($lead, $exists[0]);
-                                    $leadIpAddresses = $lead->getIpAddresses();
+                        if (count($uniqueLeadFieldData)) {
+                            $existingLeads = $this->em->getRepository('MauticLeadBundle:Lead')->getLeadsByUniqueFields(
+                                $uniqueLeadFieldData,
+                                $lead->getId()
+                            );
+                            if (!empty($existingLeads)) {
+                                $lead = $leadModel->mergeLeads($lead, $existingLeads[0]);
+                            }
+                            $leadIpAddresses = $lead->getIpAddresses();
 
-                                    if (!$leadIpAddresses->contains($ipAddress)) {
-                                        $lead->addIpAddress($ipAddress);
-                                    }
-
-                                    $leadModel->setCurrentLead($lead);
-                                }
+                            if (!$leadIpAddresses->contains($ipAddress)) {
+                                $lead->addIpAddress($ipAddress);
                             }
 
+                            $leadModel->setCurrentLead($lead);
                         }
+
                         $leadModel->setFieldValues($lead, $inQuery);
                         $leadModel->saveEntity($lead);
                     }


### PR DESCRIPTION
This adds the unique identifier support to page hits and lead api.

Also switched LeadModel::setFieldValues() to not overwrite with blank by default as it is only the processing of the lead form that this must be true.  Everywhere else, it's false.